### PR TITLE
BUGFIX: Ignore lastModification in favor of creation and publicationDates ZombieDetector.php

### DIFF
--- a/Classes/Domain/ZombieDetector.php
+++ b/Classes/Domain/ZombieDetector.php
@@ -29,17 +29,17 @@ class ZombieDetector
 
         $latestAllowedTimestamp = time() - $this->zombificationPeriod;
 
-        /** @var \DateTime|null $lastModificationDateTime */
-        $lastModificationDateTime = $node->getNodeData()->getLastModificationDateTime();
-        $lastModificationTimestamp = $lastModificationDateTime?->getTimestamp();
-
         /** @var \DateTime|null $lastPublicationDateTime */
         $lastPublicationDateTime = $node->getNodeData()->getLastPublicationDateTime();
         $lastPublicationTimestamp = $lastPublicationDateTime?->getTimestamp();
 
+        /** @var \DateTime|null $creationDateTime */
+        $creationDateTime = $node->getNodeData()->getCreationDateTime();
+        $creationTimestamp = $creationDateTime?->getTimestamp();
+
         if (
-            ($lastModificationTimestamp === null || $lastModificationTimestamp < $latestAllowedTimestamp)
-            && ($lastPublicationTimestamp === null || $lastPublicationTimestamp < $latestAllowedTimestamp)
+            ($lastPublicationTimestamp !== null && $lastPublicationTimestamp < $latestAllowedTimestamp)
+            || ($lastPublicationTimestamp === null && $creationTimestamp < $latestAllowedTimestamp)
         ) {
             return true;
         }
@@ -55,18 +55,17 @@ class ZombieDetector
 
         $latestAllowedTimestamp = time() - $this->zombificationPeriod - $this->destructionPeriod;
 
-        /** @var \DateTime|null $lastModificationDateTime */
-        $lastModificationDateTime = $node->getNodeData()->getLastModificationDateTime();
-        $lastModificationTimestamp = $lastModificationDateTime?->getTimestamp();
-
         /** @var \DateTime|null $lastPublicationDateTime */
         $lastPublicationDateTime = $node->getNodeData()->getLastPublicationDateTime();
         $lastPublicationTimestamp = $lastPublicationDateTime?->getTimestamp();
 
+        /** @var \DateTime|null $creationDateTime */
+        $creationDateTime = $node->getNodeData()->getCreationDateTime();
+        $creationTimestamp = $creationDateTime?->getTimestamp();
+
         if (
-            $node->isVisible() === false
-            && ($lastModificationTimestamp === null || $lastModificationTimestamp < $latestAllowedTimestamp)
-            && ($lastPublicationTimestamp === null || $lastPublicationTimestamp < $latestAllowedTimestamp)
+            ($lastPublicationTimestamp !== null && $lastPublicationTimestamp < $latestAllowedTimestamp)
+            || ($lastPublicationTimestamp === null && $creationTimestamp < $latestAllowedTimestamp)
         ) {
             return true;
         }


### PR DESCRIPTION
The last lastModification field is updated implicitly when any of the following fields changes. 

aus NodeData.php
```
    /**
     * @var \DateTime
     * @Gedmo\Timestampable(on="update", field={"pathHash", "parentPathHash", "identifier", "index", "contentObjectProxy", "removed", "dimensionHash", "hidden", "hiddenBeforeDateTime", "hiddenAfterDateTime", "hiddenInIndex", "nodeType", "properties"})
     */
    protected $lastModificationDateTime;
```      

This change adjusts that and now uses  the lastPublicationDate with a fallbackt to creationDate as sole source of truth for Zombie detection.